### PR TITLE
fix(vendor): replace private smallvec!/vec! macro uses in num-bigint-…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,10 +2578,7 @@ dependencies = [
 [[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -5588,8 +5585,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "num-bigint"
-version = "0.4.2"
-source = "git+https://github.com/rust-num/num-bigint.git?rev=1469ed68d16bcaa069965dcecf4cab0dbcde3b92#1469ed68d16bcaa069965dcecf4cab0dbcde3b92"

--- a/vendor/num-bigint-dig/src/algorithms/div.rs
+++ b/vendor/num-bigint-dig/src/algorithms/div.rs
@@ -1,3 +1,4 @@
+use crate::VEC_SIZE;
 use core::cmp::Ordering;
 use num_traits::{One, Zero};
 use smallvec::SmallVec;
@@ -83,7 +84,11 @@ pub fn div_rem(u: &BigUint, d: &BigUint) -> (BigUint, BigUint) {
     let bn = *b.data.last().unwrap();
     let q_len = a.data.len() - b.data.len() + 1;
     let mut q = BigUint {
-        data: smallvec![0; q_len],
+        data: {
+            let mut d: SmallVec<[BigDigit; VEC_SIZE]> = SmallVec::with_capacity(q_len);
+            d.resize(q_len, 0);
+            d
+        },
     };
 
     // We reuse the same temporary to avoid hitting the allocator in our inner loop - this is

--- a/vendor/num-bigint-dig/src/algorithms/mac.rs
+++ b/vendor/num-bigint-dig/src/algorithms/mac.rs
@@ -5,7 +5,9 @@ use crate::algorithms::{adc, add2, sub2, sub_sign};
 use crate::big_digit::{BigDigit, DoubleBigDigit, BITS};
 use crate::bigint::Sign::{Minus, NoSign, Plus};
 use crate::biguint::IntDigits;
+use crate::VEC_SIZE;
 use crate::{BigInt, BigUint};
+use smallvec::SmallVec;
 
 #[inline]
 pub fn mac_with_carry(a: BigDigit, b: BigDigit, c: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
@@ -140,7 +142,11 @@ fn karatsuba(acc: &mut [BigDigit], x: &[BigDigit], y: &[BigDigit]) {
      */
     let len = x1.len() + y1.len() + 1;
     let mut p = BigUint {
-        data: smallvec![0; len],
+        data: {
+            let mut d: SmallVec<[BigDigit; VEC_SIZE]> = SmallVec::with_capacity(len);
+            d.resize(len, 0);
+            d
+        },
     };
 
     // p2 = x1 * y1

--- a/vendor/num-bigint-dig/src/algorithms/mul.rs
+++ b/vendor/num-bigint-dig/src/algorithms/mul.rs
@@ -1,6 +1,8 @@
 use crate::algorithms::mac3;
 use crate::big_digit::{BigDigit, DoubleBigDigit, BITS};
 use crate::BigUint;
+use crate::VEC_SIZE;
+use smallvec::SmallVec;
 
 #[inline]
 pub fn mul_with_carry(a: BigDigit, b: BigDigit, acc: &mut DoubleBigDigit) -> BigDigit {
@@ -13,7 +15,11 @@ pub fn mul_with_carry(a: BigDigit, b: BigDigit, acc: &mut DoubleBigDigit) -> Big
 pub fn mul3(x: &[BigDigit], y: &[BigDigit]) -> BigUint {
     let len = x.len() + y.len() + 1;
     let mut prod = BigUint {
-        data: smallvec![0; len],
+        data: {
+            let mut d: SmallVec<[BigDigit; VEC_SIZE]> = SmallVec::with_capacity(len);
+            d.resize(len, 0);
+            d
+        },
     };
 
     mac3(&mut prod.data[..], x, y);

--- a/vendor/num-bigint-dig/src/bigrand.rs
+++ b/vendor/num-bigint-dig/src/bigrand.rs
@@ -12,11 +12,13 @@ use alloc::vec::Vec;
 use crate::big_digit::BigDigit;
 use crate::bigint::{into_magnitude, magnitude};
 use crate::integer::Integer;
+use crate::VEC_SIZE;
 #[cfg(feature = "prime")]
 use num_iter::range_step;
 use num_traits::Zero;
 #[cfg(feature = "prime")]
 use num_traits::{FromPrimitive, ToPrimitive};
+use smallvec::SmallVec;
 
 #[cfg(feature = "prime")]
 use crate::prime::probably_prime;
@@ -47,7 +49,9 @@ impl<R: Rng + ?Sized> RandBigInt for R {
     fn gen_biguint(&mut self, bit_size: usize) -> BigUint {
         use super::big_digit::BITS;
         let (digits, rem) = bit_size.div_rem(&BITS);
-        let mut data = smallvec![BigDigit::default(); digits + (rem > 0) as usize];
+        let data_len = digits + (rem > 0) as usize;
+        let mut data: SmallVec<[BigDigit; VEC_SIZE]> = SmallVec::with_capacity(data_len);
+        data.resize(data_len, BigDigit::default());
 
         // `fill` is faster than many `gen::<u32>` calls
         // Internally this calls `SeedableRng` where implementors are responsible for adjusting endianness for reproducable values.

--- a/vendor/num-bigint-dig/src/biguint.rs
+++ b/vendor/num-bigint-dig/src/biguint.rs
@@ -1805,7 +1805,11 @@ impl From<u64> for BigUint {
 impl From<u64> for BigUint {
     #[inline]
     fn from(n: u64) -> Self {
-        BigUint::new_native(smallvec![n])
+        BigUint::new_native({
+            let mut d: SmallVec<[BigDigit; VEC_SIZE]> = SmallVec::with_capacity(1);
+            d.push(n);
+            d
+        })
     }
 }
 


### PR DESCRIPTION
Replace private smallvec!/vec! macro uses in num-bigint-dig with explicit SmallVec/Vec initialization to avoid future-incompat warnings