### PR TITLE
ci: pin actions/setup-python@v5 to immutable SHA

### DIFF
--- a/.github/workflows/capnp_codegen.yml
+++ b/.github/workflows/capnp_codegen.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload capnpc diagnostics (if present)
         if: always()
-        uses: actions/upload-artifact@v4 # TODO: pin to a SHA in production workflows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: capnpc-diagnostics-${{ runner.os }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Setup Python
-        uses: actions/setup-python@v5 # TODO: pin to a SHA in production workflows
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload capnpc diagnostics (if present)
         if: always()
-        uses: actions/upload-artifact@v4 # TODO: pin to a SHA in production workflows
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: capnpc-diagnostics-${{ matrix.os }}
           path: |


### PR DESCRIPTION
Pin actions/setup-python@v5 to commit SHA a26af69be951a213d495a4c3e4e4022e16d87065 in CI workflows to satisfy supply-chain security and CodeQL. This is a small, focused pin to validate CI behavior.